### PR TITLE
Refactor part 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ test: build
 	./radroach-dev input.sql output.sql
 
 enum_test: build
-	./radroach-dev --enum-to-check input.sql output.sql
+	./radroach-dev -enum-to-check input.sql output.sql

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ radroach [FLAGS...] SOURCE_MYSQL_DUMP DESTINATION_CRDB_DUMP
 ```bash
 Usage: radroach [FLAGS...] SOURCE_MYSQL_DUMP DESTINATION_CRDB_DUMP
   -enum-to-check
-        convert enums to check constraints
-  -v    verbose logging mode
+    	convert enums to check constraints
+  -verbose
+    	verbose logging mode
 ```
 
 ## Roadmap
@@ -47,5 +48,6 @@ Usage: radroach [FLAGS...] SOURCE_MYSQL_DUMP DESTINATION_CRDB_DUMP
 - [x] Break dump down by table, extract foreign keys
 - [x] Re-write dump with foreign keys after table creation
 - [x] Produce a working SQL dump for CockroachDB
+- [ ] Refactor codebase for readability and testability
 - [ ] Test all the things
 - [ ] Cobra cmd support

--- a/main.go
+++ b/main.go
@@ -3,35 +3,17 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 )
-
-type options struct {
-	verbose     bool
-	enumToCheck bool
-	srcMySQL    string
-	dstCrDB     string
-}
-
-var opts options
-
-type verboseLogger struct{}
-
-func (v *verboseLogger) Log(err error) {
-	if opts.verbose {
-		log.Println(err)
-	}
-}
 
 func main() {
 	log.SetFlags(log.LstdFlags)
 
 	// TODO: Look at using cobra cmd for this.
 	flag.Usage = usage
-	flag.BoolVar(&opts.verbose, "v", false, "verbose logging mode")
-	flag.BoolVar(&opts.enumToCheck, "enum-to-check", false, "convert enums to check constraints")
+	verbose := flag.Bool("verbose", false, "verbose logging mode")
+	enum := flag.Bool("enum-to-check", false, "convert enums to check constraints")
 	flag.Parse()
 
 	if len(flag.Args()) < 2 {
@@ -39,54 +21,20 @@ func main() {
 		os.Exit(1)
 	}
 
-	opts.srcMySQL = flag.Args()[0]
-	if len(opts.srcMySQL) == 0 {
+	src := flag.Args()[0]
+	if len(src) == 0 {
 		usage()
 		os.Exit(1)
 	}
 
-	opts.dstCrDB = flag.Args()[1]
-	if len(opts.dstCrDB) == 0 {
+	dst := flag.Args()[1]
+	if len(dst) == 0 {
 		usage()
 		os.Exit(1)
 	}
 
-	logger := verboseLogger{}
-
-	srcInfo, err := os.Stat(opts.srcMySQL)
-	if err != nil {
-		logger.Log(fmt.Errorf("could not stat source file %q: %s", opts.srcMySQL, err))
-
-		fmt.Println("Hmm, couldn't open the source mysql file for reading. Make sure the path and permissions are correct.")
-		os.Exit(1)
-	}
-
-	// TODO: Does reading and parsing line-by-line make more sense?
-	srcData, err := ioutil.ReadFile(opts.srcMySQL)
-	if err != nil {
-		logger.Log(fmt.Errorf("could not read file %q: %s", opts.srcMySQL, err))
-
-		fmt.Println("Hmm, couldn't read the source mysql file for reading. Make sure the path and permissions are correct.")
-		os.Exit(1)
-	}
-
-	roacher := newRoacher(srcData)
-
-	crdbData, err := roacher.roach()
-	if err != nil {
-		logger.Log(fmt.Errorf("could not roach mysql data: %s", err))
-
-		fmt.Println("Damn, couldn't convert the mysql dump to crdb. Make sure the source file was prepared correctly.")
-		os.Exit(1)
-	}
-
-	err = ioutil.WriteFile(opts.dstCrDB, crdbData, srcInfo.Mode())
-	if err != nil {
-		logger.Log(fmt.Errorf("could not save the crdb data to file %q: %s", opts.dstCrDB, err))
-
-		fmt.Println("Oh dear, couldn't write the crdb data. Make sure you have the correct permissions.")
-		os.Exit(1)
-	}
+	rr := newRadRoach(src, dst, verboseLogging(*verbose), enumToCheck(*enum))
+	rr.run()
 }
 
 func usage() {

--- a/main.go
+++ b/main.go
@@ -19,9 +19,9 @@ func main() {
 	}
 
 	src := flag.Args()[0]
-  dst := flag.Args()[1]
+	dst := flag.Args()[1]
 
-  if len(src) == 0 || len(dst) == 0 {
+	if len(src) == 0 || len(dst) == 0 {
 		usage()
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 )
 
 func main() {
-	log.SetFlags(log.LstdFlags)
-
 	// TODO: Look at using cobra cmd for this.
 	flag.Usage = usage
 	verbose := flag.Bool("verbose", false, "verbose logging mode")

--- a/main.go
+++ b/main.go
@@ -19,13 +19,9 @@ func main() {
 	}
 
 	src := flag.Args()[0]
-	if len(src) == 0 {
-		usage()
-		os.Exit(1)
-	}
+  dst := flag.Args()[1]
 
-	dst := flag.Args()[1]
-	if len(dst) == 0 {
+  if len(src) == 0 || len(dst) == 0 {
 		usage()
 		os.Exit(1)
 	}

--- a/radroach.go
+++ b/radroach.go
@@ -172,9 +172,11 @@ func (r *radroach) roach(input []byte) (output []byte, err error) {
 
 // log only logs errors if radroach is in verbose mode.
 func (r *radroach) log(err error) {
-	if r.verbose {
-		log.Println(err)
+	if !r.verbose {
+		return
 	}
+
+	r.logger.Println(err)
 }
 
 // enumToCheck returns an option modifier to enable enum to check contraints.
@@ -195,8 +197,9 @@ func verboseLogging(v bool) option {
 // file, destination file and any options.
 func newRadRoach(src, dst string, opts ...option) *radroach {
 	rr := &radroach{
-		src: src,
-		dst: dst,
+		src:    src,
+		dst:    dst,
+		logger: log.New(os.Stdout, "", log.LstdFlags),
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
First pass at a refactor, targeted at tidying the global state. Next step is to modularise the _roaching_ process

## Changes
* Introduced new radroach struct to manage config.
* Introduced functional options pattern to toggle verbose logging and enum-to-check functionality.
* Refactored the enum to check logic accordingly.
* Removed verboseLogger struct, now part of radroach.
* Refactored logging to use radroach scoped logger instead of global